### PR TITLE
outlet methods was moved to 4th, but never updated in title

### DIFF
--- a/04-outlet-methods/outlet-methods.maxpat
+++ b/04-outlet-methods/outlet-methods.maxpat
@@ -247,7 +247,7 @@
 					"numinlets" : 1,
 					"numoutlets" : 0,
 					"patching_rect" : [ 10.0, 10.0, 492.0, 64.0 ],
-					"text" : "03 - Outlet Methods"
+					"text" : "04 - Outlet Methods"
 				}
 
 			}


### PR DESCRIPTION
I have verified that this pull request:

* [ X] there are no linting errors -- `npm run lint`, from the root of the n4m-examples repository
* [X ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ X] is descriptively named and links to an issue number, i.e. `Fixes #123`

Thank you!
